### PR TITLE
move unused deps into dev-deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,13 +31,12 @@
   },
   "devDependencies": {
     "mocha": "*",
-    "should": "*"
-  },
-  "keywords": [],
-  "dependencies": {
+    "should": "*",
     "accountdown": "^4.0.0",
     "level": "^0.18.0",
     "mkdirp": "^0.5.0",
     "rimraf": "^2.2.8"
-  }
+  },
+  "keywords": [],
+  "dependencies": {}
 }


### PR DESCRIPTION
All dependencies listed in `dependencies` object are actually `dev-dependencies`. Listing them as such will greatly improve install time and rid project of unnecessary deps.
